### PR TITLE
Create initial deployment guide.

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,14 @@
+# Rietta Application Deployment Guide
+
+We support a number of client projects in a variety of deployment environments. 
+This guide aims to centralize the setup and operational steps required for each type of deployment environment we use.
+
+## Elastic Beanstalk (AKA EB)
+
+Fill this in ASAP
+
+## Heroku
+
+## Capistrano (targeting Linode, Rackspace, etc)
+
+Generally this requires having your ssh public key distributed to the servers in question, which might also involve an entry in your local `~/.ssh/config` file. After that, it should be automatic or interactively guided by running `$YOUR_PROJECT_ROOT/bin/deploy`

--- a/deployment.md
+++ b/deployment.md
@@ -9,6 +9,8 @@ Fill this in ASAP
 
 ## Heroku
 
+use Heroku CLI or `git push heroku master` or use heroku dashboard to set up deploy via github.
+
 ## Capistrano (targeting Linode, Rackspace, etc)
 
 Generally this requires having your ssh public key distributed to the servers in question, which might also involve an entry in your local `~/.ssh/config` file. After that, it should be automatic or interactively guided by running `$YOUR_PROJECT_ROOT/bin/deploy`

--- a/deployment.md
+++ b/deployment.md
@@ -5,7 +5,10 @@ This guide aims to centralize the setup and operational steps required for each 
 
 ## Elastic Beanstalk (AKA EB)
 
-Fill this in ASAP
+Install the aws eb client.
+Ensure there is a `.elasticbeanstalk/config.yml` set up in your project root (should be gitignored by default).
+
+Assuming your IAM credentials are set up within the AWS console, and your eb configuration files are set up correctly locally, run `eb deploy` from the project root.
 
 ## Heroku
 


### PR DESCRIPTION
I was unable to quickly set up my local system and deploy to a new EB environment,
so I wanted to have a quick reference in place for future usage to avoid being
delayed on these kinds of things in the future.